### PR TITLE
HOT-FIX-5: Fix missing change eventlistener in media watch

### DIFF
--- a/src/components/navbar/Navbar.js
+++ b/src/components/navbar/Navbar.js
@@ -21,9 +21,9 @@ function Navbar () {
             }
         } else {
             // backwards compatibility
-            mediaWatcher.addListener(updateIsNarrowScreen);
+            mediaWatcher.addListener('change', updateIsNarrowScreen);
             return function cleanup() {
-                mediaWatcher.removeListener(updateIsNarrowScreen);
+                mediaWatcher.removeListener('change', updateIsNarrowScreen);
             }
         }
     });


### PR DESCRIPTION
Issue: Media watch still did not work in iphone browsers

Solution: add missing change eventlistener 